### PR TITLE
Fix/chip line height

### DIFF
--- a/packages/Chip/index.vue
+++ b/packages/Chip/index.vue
@@ -26,7 +26,8 @@ export default {
 
 .label-chips {
   font-size: $fs-12;
-  line-height: 1.67;
+  line-height: 20px;
+  min-height: 20px;
   color: $white;
   background-color: $gray;
   border-radius: 2px;


### PR DESCRIPTION
Fix line-height of chip when root `font-size: 14px`

![Screenshot_20191005-115531](https://user-images.githubusercontent.com/4949470/66249818-cee2d580-e76b-11e9-941a-f88223ddf4ea.png)
![Screenshot_20191005-115536](https://user-images.githubusercontent.com/4949470/66249820-d0140280-e76b-11e9-9976-981246ed5ad7.png)
